### PR TITLE
feat: load additional templates

### DIFF
--- a/docs/templates/overview.md
+++ b/docs/templates/overview.md
@@ -69,3 +69,20 @@ contemplate \
     However, it is an error to specify standard input as multiple source or destination values.
 
 [minijinja-compat]: https://github.com/mitsuhiko/minijinja/blob/main/COMPATIBILITY.md
+
+## Additional templates
+
+Additional templates can be loaded from the file system with the `--additional-templates` / `-a` argument. The specified directory will be added as a search path. Template files contained within can now be referenced by their relative path. They are loaded on demand the first time they are referenced in a template.
+
+For example, if you had the following file structure:
+
+```
+extra_templates
+├── content
+│   └── news.txt
+└── macros.j2
+```
+
+Then you could call `contemplate -a extra_templates` and refer to the files as `macros.j2` and `content/news.txt`.
+
+For details on how to refer to additional templates, read the minijinja documentation about [`extends`](https://docs.rs/minijinja/latest/minijinja/syntax/index.html#-extends-), [`include`](https://docs.rs/minijinja/latest/minijinja/syntax/index.html#-include-) and [`import`](https://docs.rs/minijinja/latest/minijinja/syntax/index.html#-import-).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -314,6 +314,16 @@ impl Cli {
             .or_else(|| env::var("CONTEMPLATE_K8S_NAMESPACE").ok())
     }
 
+    /// The additional-templates argument
+    ///
+    /// Attempts to take this from the `--additional-templates` argument, falling back to the `CONTEMPLATE_ADDITIONAL_TEMPLATES` environment variable.
+    pub fn additional_templates(&self) -> Option<String> {
+        self.matches
+            .get_one::<String>("additional-templates")
+            .map(ToOwned::to_owned)
+            .or_else(|| env::var("CONTEMPLATE_ADDITIONAL_TEMPLATES").ok())
+    }
+
     /// Should editing be done in-place
     pub fn in_place(&self) -> InPlace {
         if self.matches.get_occurrences::<String>("in-place").is_some() {
@@ -550,6 +560,21 @@ fn command() -> Command {
                 .action(ArgAction::Append)
                 .conflicts_with("output")
                 .conflicts_with("input"),
+        )
+        .arg(
+            Arg::new("additional-templates")
+                .long("additional-templates")
+                .short('a')
+                .action(ArgAction::Set)
+                .value_name("DIRECTORY")
+                .num_args(1)
+                .value_hint(ValueHint::DirPath)
+                .help("Directory from which additional templates are loaded.")
+                .long_help(indoc! {
+                    "Directory from which additional templates are loaded.
+
+                    Needed for 'extends', 'include' and 'import' tags."
+                }),
         )
         .arg(
             Arg::new("input")

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,9 @@ fn main() -> Result<()> {
 
     let mut env = minijinja::Environment::new();
     env.set_undefined_behavior(minijinja::UndefinedBehavior::Chainable);
+    if let Some(load_path) = cli.additional_templates() {
+        env.set_loader(minijinja::path_loader(load_path));
+    }
     filters::register(&mut env);
     functions::register(&mut env);
     if let Err(e) = plan.ensure_cached(&mut env) {


### PR DESCRIPTION
This allows loading additional templates from the file system for use with `extends`, `include` and `import` blocks.